### PR TITLE
Fix compiler warnings

### DIFF
--- a/NAM/convnet.cpp
+++ b/NAM/convnet.cpp
@@ -106,7 +106,7 @@ convnet::ConvNet::ConvNet(const double loudness, const int channels, const std::
   this->_verify_params(channels, dilations, batchnorm, params.size());
   this->_blocks.resize(dilations.size());
   std::vector<float>::iterator it = params.begin();
-  for (int i = 0; i < dilations.size(); i++)
+  for (size_t i = 0; i < dilations.size(); i++)
     this->_blocks[i].set_params_(i == 0 ? 1 : channels, channels, dilations[i], batchnorm, activation, it);
   this->_block_vals.resize(this->_blocks.size() + 1);
   this->_head = _Head(channels, it);
@@ -125,7 +125,7 @@ void convnet::ConvNet::_process_core_()
   // TODO one unnecessary copy :/ #speed
   for (auto i = i_start; i < i_end; i++)
     this->_block_vals[0](0, i) = this->_input_buffer[i];
-  for (auto i = 0; i < this->_blocks.size(); i++)
+  for (size_t i = 0; i < this->_blocks.size(); i++)
     this->_blocks[i].process_(this->_block_vals[i], this->_block_vals[i + 1], i_start, i_end);
   // TODO clean up this allocation
   this->_head.process_(this->_block_vals[this->_blocks.size()], this->_head_output, i_start, i_end);
@@ -145,9 +145,9 @@ void convnet::ConvNet::_verify_params(const int channels, const std::vector<int>
 void convnet::ConvNet::_update_buffers_()
 {
   this->Buffer::_update_buffers_();
-  const long buffer_size = this->_input_buffer.size();
+  const size_t buffer_size = this->_input_buffer.size();
   this->_block_vals[0].resize(1, buffer_size);
-  for (long i = 1; i < this->_block_vals.size(); i++)
+  for (size_t i = 1; i < this->_block_vals.size(); i++)
     this->_block_vals[i].resize(this->_blocks[i - 1].get_out_channels(), buffer_size);
 }
 
@@ -157,7 +157,7 @@ void convnet::ConvNet::_rewind_buffers_()
   // resets the offset index
   // The last _block_vals is the output of the last block and doesn't need to be
   // rewound.
-  for (long k = 0; k < this->_block_vals.size() - 1; k++)
+  for (size_t k = 0; k < this->_block_vals.size() - 1; k++)
   {
     // We actually don't need to pull back a lot...just as far as the first
     // input sample would grab from dilation
@@ -176,7 +176,7 @@ void convnet::ConvNet::_anti_pop_()
   if (this->_anti_pop_countdown >= this->_anti_pop_ramp)
     return;
   const float slope = 1.0f / float(this->_anti_pop_ramp);
-  for (int i = 0; i < this->_core_dsp_output.size(); i++)
+  for (size_t i = 0; i < this->_core_dsp_output.size(); i++)
   {
     if (this->_anti_pop_countdown >= this->_anti_pop_ramp)
       break;
@@ -190,7 +190,7 @@ void convnet::ConvNet::_reset_anti_pop_()
 {
   // You need the "real" receptive field, not the buffers.
   long receptive_field = 1;
-  for (int i = 0; i < this->_blocks.size(); i++)
+  for (size_t i = 0; i < this->_blocks.size(); i++)
     receptive_field += this->_blocks[i].conv.get_dilation();
   this->_anti_pop_countdown = -receptive_field;
 }

--- a/NAM/get_dsp.cpp
+++ b/NAM/get_dsp.cpp
@@ -150,7 +150,7 @@ std::unique_ptr<DSP> get_dsp(dspData& conf)
     const int channels = config["channels"];
     const bool batchnorm = config["batchnorm"];
     std::vector<int> dilations;
-    for (int i = 0; i < config["dilations"].size(); i++)
+    for (size_t i = 0; i < config["dilations"].size(); i++)
       dilations.push_back(config["dilations"][i]);
     const std::string activation = config["activation"];
     return std::make_unique<convnet::ConvNet>(loudness, channels, dilations, batchnorm, activation, params);
@@ -173,11 +173,11 @@ std::unique_ptr<DSP> get_dsp(dspData& conf)
   else if (architecture == "WaveNet" || architecture == "CatWaveNet")
   {
     std::vector<wavenet::LayerArrayParams> layer_array_params;
-    for (int i = 0; i < config["layers"].size(); i++)
+    for (size_t i = 0; i < config["layers"].size(); i++)
     {
       nlohmann::json layer_config = config["layers"][i];
       std::vector<int> dilations;
-      for (int j = 0; j < layer_config["dilations"].size(); j++)
+      for (size_t j = 0; j < layer_config["dilations"].size(); j++)
         dilations.push_back(layer_config["dilations"][j]);
       layer_array_params.push_back(
         wavenet::LayerArrayParams(layer_config["input_size"], layer_config["condition_size"], layer_config["head_size"],

--- a/NAM/lstm.cpp
+++ b/NAM/lstm.cpp
@@ -111,7 +111,7 @@ void lstm::LSTM::_process_core_()
     this->_stale_params = false;
   }
   // Process samples, placing results in the required output location
-  for (int i = 0; i < this->_input_post_gain.size(); i++)
+  for (size_t i = 0; i < this->_input_post_gain.size(); i++)
     this->_core_dsp_output[i] = this->_process_sample(this->_input_post_gain[i]);
 }
 
@@ -121,7 +121,7 @@ float lstm::LSTM::_process_sample(const float x)
     return x;
   this->_input_and_params(0) = x;
   this->_layers[0].process_(this->_input_and_params);
-  for (int i = 1; i < this->_layers.size(); i++)
+  for (size_t i = 1; i < this->_layers.size(); i++)
     this->_layers[i].process_(this->_layers[i - 1].get_hidden_state());
   return this->_head_weight.dot(this->_layers[this->_layers.size() - 1].get_hidden_state()) + this->_head_bias;
 }

--- a/NAM/wavenet.h
+++ b/NAM/wavenet.h
@@ -23,11 +23,11 @@ class _Layer
 public:
   _Layer(const int condition_size, const int channels, const int kernel_size, const int dilation,
          const std::string activation, const bool gated)
-  : _activation(activations::Activation::get_activation(activation))
-  , _gated(gated)
-  , _conv(channels, gated ? 2 * channels : channels, kernel_size, true, dilation)
+  : _conv(channels, gated ? 2 * channels : channels, kernel_size, true, dilation)
   , _input_mixin(condition_size, gated ? 2 * channels : channels, false)
-  , _1x1(channels, channels, true){};
+  , _1x1(channels, channels, true)
+  , _activation(activations::Activation::get_activation(activation))
+  , _gated(gated){};
   void set_params_(std::vector<float>::iterator& params);
   // :param `input`: from previous layer
   // :param `output`: to next layer
@@ -67,7 +67,7 @@ public:
   , gated(gated_)
   , head_bias(head_bias_)
   {
-    for (int i = 0; i < dilations_.size(); i++)
+    for (size_t i = 0; i < dilations_.size(); i++)
       this->dilations.push_back(dilations_[i]);
   };
 


### PR DESCRIPTION
This PR fixes several compiler warnings generated by GCC under Linux.
They are quite a few but related to just 2 issues:
1. Comparison of signed vs unsigned types (because `std::vector<>::size()` returns `size_t` which is unsigned)
2. C++ class constructors have wrong member initialization order

